### PR TITLE
ci: push release tag via GitHub App token so announce workflow fires

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,8 +43,18 @@ jobs:
       id-token: write
       attestations: write
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ vars.AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.AUTOMATION_APP_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -88,3 +98,4 @@ jobs:
         with:
           tag_name: v${{ steps.package.outputs.version }}
           generate_release_notes: true
+          token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
The publish workflow pushed the release tag using the default GITHUB_TOKEN. GitHub does not dispatch workflows for events created by GITHUB_TOKEN, so announce.yml (triggered on tag push) never ran for v1.1.3 through v1.2.2. This mints a short-lived fetch-kit-automation App token and pushes the tag with it, restoring the Discord announcement trigger.